### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/tests/testthat/test_output.R
+++ b/tests/testthat/test_output.R
@@ -28,7 +28,11 @@ test_that("Plot layers match expectations", {
 
 test_that("Scale is labelled 'r'", {
   p <- plot(dbl)
-  expect_identical(p$labels$y, "r")
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    expect_identical(get_labs(p)$y, "r")
+  } else {
+    expect_identical(p$labels$y, "r")
+  }
 })
 
 test_that("Scale range is NULL", {


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the sport package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes a test to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun